### PR TITLE
Fix: cast strtoupper argument to string because of strict types

### DIFF
--- a/src/RedisInstrumentation.php
+++ b/src/RedisInstrumentation.php
@@ -321,7 +321,7 @@ class RedisInstrumentation
                     $statement = 'SET ' . $params[0] . ' ?';
                     if (isset($params[2])) {
                         foreach ($params[2] as $key => $value) {
-                            $statement .= ' ' . strtoupper($key) . ' ' . $value;
+                            $statement .= ' ' . strtoupper((string) $key) . ' ' . $value;
                         }
                     }
                     $builder->setAttribute(


### PR DESCRIPTION
`strtoupper` function accepts string as argument. Key can be integer so it causes error in environment with script types.