### PR TITLE
Downgrade minimum PHP version in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "license": "Apache-2.0",
     "minimum-stability": "dev",
     "require": {
-        "php": "^8.2",
+        "php": "^8.1",
         "ext-opentelemetry": "*",
         "open-telemetry/api": "^1.0",
         "open-telemetry/sem-conv": "^1.23"


### PR DESCRIPTION
Unless I'm missing something, we aren't currently using any PHP 8.2 backwards-incompatible feature. This should allow for easier adoption in older projects.