### PR TITLE
Handle non-array param of \Redis::set call

### DIFF
--- a/src/RedisInstrumentation.php
+++ b/src/RedisInstrumentation.php
@@ -320,7 +320,6 @@ class RedisInstrumentation
                 if ($class === \Redis::class) {
                     $statement = 'SET ' . $params[0] . ' ?';
                     if (isset($params[2])) {
-                        // Third param could be the expiry time
                         // @see: https://github.com/phpredis/phpredis?tab=readme-ov-file#parameters-23
                         if (is_int($params[2])) {
                             $params[2] = ['EX' => $params[2]];

--- a/src/RedisInstrumentation.php
+++ b/src/RedisInstrumentation.php
@@ -320,6 +320,12 @@ class RedisInstrumentation
                 if ($class === \Redis::class) {
                     $statement = 'SET ' . $params[0] . ' ?';
                     if (isset($params[2])) {
+                        // Third param could be the expiry time
+                        // @see: https://github.com/phpredis/phpredis?tab=readme-ov-file#parameters-23
+                        if (is_int($params[2])) {
+                            $params[2] = ['EX' => $params[2]];
+                        }
+
                         foreach ($params[2] as $key => $value) {
                             $statement .= ' ' . strtoupper((string) $key) . ' ' . $value;
                         }


### PR DESCRIPTION
PHP Redis extension allows the user to set an expiry when setting a key/value pair, as a third param:
```php
$redis->set('key', 'value', 10); // Acceptable
```

But `RedisInstrumentation` always expects the third param to be array, which results in an error when `int` is passed.
```php
if (isset($params[2])) {
    // error if $params[2] is an integer
    foreach ($params[2] as $key => $value) {
        $statement .= ' ' . strtoupper((string) $key) . ' ' . $value;
    }
}
``` 