### PR TITLE
feat: handle string host parameters in Predis instrumentation

### DIFF
--- a/src/PredisInstrumentation.php
+++ b/src/PredisInstrumentation.php
@@ -52,9 +52,18 @@ class PredisInstrumentation
                 )
                     ->setSpanKind(SpanKind::KIND_CLIENT);
                 $host = $params[0];
-                if (array_is_list($host)) {
+                
+                if (is_string($host)) {
+                    $value = parse_url($host);
+                    if ($value) {
+                        $host = $value;
+                    }
+                }
+                
+                if (is_array($host) && array_is_list($host)) {
                     $host = $host[0];
                 }
+                
                 if ($class === \Predis\Client::class) {
                     $builder->setAttribute(TraceAttributes::SERVER_ADDRESS, $host['host'] ?? $host['path'] ?? 'unknown')
                         ->setAttribute(TraceAttributes::NETWORK_TRANSPORT, $host['scheme'] ?? 'unknown');
@@ -66,6 +75,7 @@ class PredisInstrumentation
                         $builder->setAttribute(TraceAttributes::DB_USER, $auth[0]);
                     }
                 }
+                
                 $parent = Context::getCurrent();
                 $span = $builder->startSpan();
                 Context::storage()->attach($span->storeInContext($parent));


### PR DESCRIPTION
Our team was getting warnings when using string connection URIs like `"tcp://127.0.0.1:6379"` with Predis. The hook was calling `array_is_list()` on the param without checking if it's actually an array first.

This MR fixes the issue by: 1) converting an URI string to a list with `parse_url`, and 2) adding an `is_array()` check before the `array_is_list()` call to safeguard. 

For reference, this is the issue we were seeing:  `PHP Warning:  Predis\\Client::__construct(): OpenTelemetry: pre hook threw exception, class=Predis\\Client function=__construct message=array_is_list(): Argument #1 ($array) must be of type array, string given in Unknown on line 0.`